### PR TITLE
Fix build with GnuTLS >= 3.4.0

### DIFF
--- a/src/encrypt.cpp
+++ b/src/encrypt.cpp
@@ -175,10 +175,8 @@ net6::tcp_encrypted_socket_base::
                                   gnutls_session_t sess):
 	tcp_client_socket(cobj), session(sess), state(DEFAULT)
 {
-	const int kx_prio[] = { GNUTLS_KX_ANON_DH, 0 };
-
 	gnutls_set_default_priority(session);
-	gnutls_kx_set_priority(session, kx_prio);
+	gnutls_priority_set_direct(session, "NORMAL:+ANON-DH", NULL);
 
 	gnutls_transport_set_ptr(
 		session,


### PR DESCRIPTION
- gnutls_kx_set_priority() has been removed in 3.4.0 and gnutls_priority_set_direct() should be used instead.
- This fixes github issue #1 
